### PR TITLE
Added class prefix for ObjC clients

### DIFF
--- a/proto/payload.proto
+++ b/proto/payload.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option objc_class_prefix = "HAM";
+
 message Payload {
   required uint64 at = 1;
   required string event = 2;


### PR DESCRIPTION
This prefix is needed for the Objective-C clients, as there is no namespace support in this language. For more information please see [Google's documentation](https://github.com/google/protobuf/tree/master/objectivec#objective-c-generator-options) on it.